### PR TITLE
Let a second click on the marker tool turn it off

### DIFF
--- a/js/map/map-tools.js
+++ b/js/map/map-tools.js
@@ -1474,6 +1474,18 @@ function initMapTools() {
             event.stopPropagation();
 
             if (
+                MAP_TOOL_STATE.tool ===
+                'marker' &&
+                isMapToolMenuOpen(
+                    'markerPicker'
+                )
+            ) {
+                closeMapToolMenus();
+                setMapTool('marker');
+                return;
+            }
+
+            if (
                 MAP_TOOL_STATE.tool !==
                 'marker'
             ) {


### PR DESCRIPTION
Clicking the marker tool button a second time only closed the marker picker, leaving the tool armed.

The handler never called setMapTool(), which is what performs the toggle back to null, so the ruler and eraser buttons toggled off correctly but the marker button did not.

Added an early return that closes the picker and calls setMapTool('marker') when the tool is already active and the picker is open. The picker-open check keeps the case where the picker was dismissed by clicking the map: the next click reopens it instead of deselecting the tool.
