### PR TITLE
Derive saved target highlight from the current target position

### DIFF
--- a/js/core/core.js
+++ b/js/core/core.js
@@ -39,7 +39,6 @@ let drag = null;
 let pan = null;
 
 let savedTargets = [];
-let selectedSavedTargetId = null;
 
 const SAVED_TARGETS_KEY =
     'wardogs-saved-targets';

--- a/js/events.js
+++ b/js/events.js
@@ -376,9 +376,6 @@ function bindEvents() {
                 bounds.minY
             };
 
-            selectedSavedTargetId =
-                null;
-
             inputs();
 
             renderSavedTargets();

--- a/js/features/coordinates.js
+++ b/js/features/coordinates.js
@@ -209,7 +209,6 @@ function applySharedCoordinates(
 
     inputPoint(type);
 
-    selectedSavedTargetId = null;
     renderSavedTargets();
 
     return true;

--- a/js/features/saved-targets.js
+++ b/js/features/saved-targets.js
@@ -12,6 +12,77 @@ const SAVED_TARGET_EXPORT_VERSION = 1;
 
 const SAVED_TARGET_IMPORT_LIMIT = 500;
 
+/*
+ * Both sides of the comparison have been through clamp(), which rounds
+ * to a fixed precision, so they land on the same quantum — but that
+ * rounding is a float division, so === is not safe to lean on.
+ */
+const SAVED_TARGET_MATCH_EPSILON = 1e-6;
+
+/*
+ * Which saved target the list highlights is derived from where the
+ * target actually sits, never tracked separately, so every writer of
+ * S.target keeps the highlight honest without having to know about it.
+ */
+function activeSavedTargetId() {
+
+    if (
+        !S.target ||
+        !Number.isFinite(S.target.x) ||
+        !Number.isFinite(S.target.y)
+    ) {
+        return null;
+    }
+
+    const match =
+        savedTargets.find(
+            target =>
+                Math.abs(
+                    Number(target.x) -
+                    S.target.x
+                ) < SAVED_TARGET_MATCH_EPSILON &&
+                Math.abs(
+                    Number(target.y) -
+                    S.target.y
+                ) < SAVED_TARGET_MATCH_EPSILON
+        );
+
+    return match
+        ? match.id
+        : null;
+}
+
+/*
+ * inputs() runs on every frame of a map drag, so this toggles the class
+ * on the rows already in the DOM rather than rebuilding the list. A
+ * full renderSavedTargets() is still what runs when the targets
+ * themselves change.
+ */
+function refreshSavedTargetHighlight() {
+
+    const container =
+        $('savedTargetsList');
+
+    if (!container) {
+        return;
+    }
+
+    const activeId =
+        activeSavedTargetId();
+
+    container
+        .querySelectorAll('.saved-target')
+        .forEach(
+            item => {
+                item.classList.toggle(
+                    'active',
+                    item.dataset.targetId ===
+                    activeId
+                );
+            }
+        );
+}
+
 function generateTargetId() {
 
     return (
@@ -492,11 +563,6 @@ async function importSavedTargets() {
             ...imported.targets
         );
 
-        selectedSavedTargetId =
-            imported.targets.length === 1
-                ? imported.targets[0].id
-                : selectedSavedTargetId;
-
         persistSavedTargets();
         renderSavedTargets();
 
@@ -578,9 +644,6 @@ function saveCurrentTarget() {
         target
     );
 
-    selectedSavedTargetId =
-        target.id;
-
     persistSavedTargets();
 
     if (
@@ -615,13 +678,6 @@ function deleteTarget(id) {
         index,
         1
     );
-
-    if (
-        selectedSavedTargetId === id
-    ) {
-        selectedSavedTargetId =
-            null;
-    }
 
     persistSavedTargets();
 
@@ -694,9 +750,6 @@ function restoreTarget(target) {
     clamp(S.target);
     clamp(S.origin);
 
-    selectedSavedTargetId =
-        target.id;
-
     if (
         typeof trackAnalytics ===
         'function'
@@ -764,6 +817,9 @@ function renderSavedTargets() {
         return;
     }
 
+    const activeId =
+        activeSavedTargetId();
+
     savedTargets.forEach(
         target => {
 
@@ -775,9 +831,12 @@ function renderSavedTargets() {
             item.className =
                 'saved-target';
 
+            item.dataset.targetId =
+                target.id;
+
             if (
                 target.id ===
-                selectedSavedTargetId
+                activeId
             ) {
                 item.classList.add(
                     'active'

--- a/js/features/saved-targets.js
+++ b/js/features/saved-targets.js
@@ -20,23 +20,26 @@ const SAVED_TARGET_IMPORT_LIMIT = 500;
 const SAVED_TARGET_MATCH_EPSILON = 1e-6;
 
 /*
- * Which saved target the list highlights is derived from where the
+ * Which saved targets the list highlights is derived from where the
  * target actually sits, never tracked separately, so every writer of
  * S.target keeps the highlight honest without having to know about it.
  */
-function activeSavedTargetId() {
+function activeSavedTargetIds() {
+
+    const active = new Set();
 
     if (
         !S.target ||
         !Number.isFinite(S.target.x) ||
         !Number.isFinite(S.target.y)
     ) {
-        return null;
+        return active;
     }
 
-    const match =
-        savedTargets.find(
-            target =>
+    savedTargets.forEach(
+        target => {
+
+            if (
                 Math.abs(
                     Number(target.x) -
                     S.target.x
@@ -45,11 +48,15 @@ function activeSavedTargetId() {
                     Number(target.y) -
                     S.target.y
                 ) < SAVED_TARGET_MATCH_EPSILON
-        );
+            ) {
+                active.add(
+                    String(target.id)
+                );
+            }
+        }
+    );
 
-    return match
-        ? match.id
-        : null;
+    return active;
 }
 
 /*
@@ -67,8 +74,8 @@ function refreshSavedTargetHighlight() {
         return;
     }
 
-    const activeId =
-        activeSavedTargetId();
+    const activeIds =
+        activeSavedTargetIds();
 
     container
         .querySelectorAll('.saved-target')
@@ -76,8 +83,9 @@ function refreshSavedTargetHighlight() {
             item => {
                 item.classList.toggle(
                     'active',
-                    item.dataset.targetId ===
-                    activeId
+                    activeIds.has(
+                        item.dataset.targetId
+                    )
                 );
             }
         );
@@ -817,8 +825,8 @@ function renderSavedTargets() {
         return;
     }
 
-    const activeId =
-        activeSavedTargetId();
+    const activeIds =
+        activeSavedTargetIds();
 
     savedTargets.forEach(
         target => {
@@ -835,8 +843,9 @@ function renderSavedTargets() {
                 target.id;
 
             if (
-                target.id ===
-                activeId
+                activeIds.has(
+                    String(target.id)
+                )
             ) {
                 item.classList.add(
                     'active'

--- a/js/map/map-tools.js
+++ b/js/map/map-tools.js
@@ -84,8 +84,7 @@ function snapshotMapToolContent() {
         markers: structuredClone(MAP_TOOL_STATE.markers),
         origin: structuredClone(S.origin),
         target: structuredClone(S.target),
-        mode: S.mode,
-        selectedSavedTargetId
+        mode: S.mode
     };
 }
 
@@ -142,9 +141,6 @@ function restoreMapToolContent(snapshot) {
     ) {
         S.mode = snapshot.mode;
     }
-
-    selectedSavedTargetId =
-        snapshot.selectedSavedTargetId || null;
 
     $('originMode')?.classList.toggle(
         'active',

--- a/js/map/overlays.js
+++ b/js/map/overlays.js
@@ -960,9 +960,6 @@ function selectPresetMarkerAsTarget(
     S.mode =
         'target';
 
-    selectedSavedTargetId =
-        null;
-
     $('targetMode')
         ?.classList
         .add(

--- a/js/mobile/mobile.js
+++ b/js/mobile/mobile.js
@@ -461,7 +461,6 @@ function finishMobileTap(event, gesture) {
     };
 
     clamp(S[pointType]);
-    selectedSavedTargetId = null;
 
     if (
         typeof trackAnalytics ===

--- a/js/ui/inputs.js
+++ b/js/ui/inputs.js
@@ -24,6 +24,17 @@ function inputs() {
     $('h').value =
         S.h;
 
+    /*
+     * The saved-target highlight is derived from where the target sits,
+     * so every writer of S.target refreshes it by arriving here.
+     */
+    if (
+        typeof refreshSavedTargetHighlight ===
+        'function'
+    ) {
+        refreshSavedTargetHighlight();
+    }
+
     result();
     draw();
 }


### PR DESCRIPTION
## Derive the saved-target highlight from the target position

Which saved-target row is highlighted was tracked in a separate `selectedSavedTargetId` variable, which every writer of `S.target` had to remember to clear. Several did not, so the highlight could point at a row the target had long since moved away from.

This computes it instead: a row is active when its coordinates match where the target actually sits. The variable is gone, along with the seven sites that maintained it.

Coordinates are compared with an epsilon rather than `===`, because `clamp()` rounds through a float division and a saved target's stored numbers were themselves clamped before being written.

`refreshSavedTargetHighlight()` is separate from `renderSavedTargets()` on purpose: `inputs()` runs on every frame of a map drag, so it toggles the class on rows already in the DOM instead of rebuilding the list. A full render still runs when the targets themselves change.

Note that dragging the target onto a saved target's exact coordinates now highlights that row. That is the intended meaning of the highlight under this change: the target is at this saved position.