### PR TITLE
FOB build areas, rotatable, with draggable placed markers

### DIFF
--- a/config/app.json
+++ b/config/app.json
@@ -28,6 +28,12 @@
     "camera": {
       "maxZoom": 100,
       "panSpeed": 800
+    },
+    "rings": {
+      "fob": {
+        "halfSide": 60,
+        "color": "#5fa8d3"
+      }
     }
   }
 }

--- a/js/core/config.js
+++ b/js/core/config.js
@@ -7,6 +7,22 @@ const DEFAULT_APP_CONFIG = {
         camera: {
             maxZoom: 100,
             panSpeed: 800
+        },
+
+        /*
+         * A FOB build area is a square, so it is measured by `halfSide`:
+         * the distance from the FOB to an edge, and the buildable side is
+         * twice it. There is no circle involved and no radius to name.
+         *
+         * The 60 m half-side is confirmed from the game data — the build
+         * area is a 120 x 120 m square. Override it in config/app.json
+         * rather than here.
+         */
+        rings: {
+            fob: {
+                halfSide: 60,
+                color: '#5fa8d3'
+            }
         }
     },
 
@@ -54,6 +70,14 @@ function mergeAppConfig(base, override) {
             camera: {
                 ...base.map.camera,
                 ...(override?.map?.camera || {})
+            },
+            rings: {
+                ...base.map.rings,
+                ...(override?.map?.rings || {}),
+                fob: {
+                    ...base.map.rings.fob,
+                    ...(override?.map?.rings?.fob || {})
+                }
             }
         },
 
@@ -112,6 +136,55 @@ function getMapToolShortcut(action) {
     )
         .trim()
         .toLowerCase();
+}
+
+/*
+ * A ring kind names its own measurement key in config/app.json rather than
+ * sharing one that would only be honest about some of them: a FOB build area
+ * has a `halfSide`. The measurement comes back as `size`, so the drawing code
+ * does not have to know which kind it was handed.
+ */
+const RING_SIZE_KEYS = {
+    fob: 'halfSide'
+};
+
+function getRingConfig(kind) {
+
+    const fallback =
+        DEFAULT_APP_CONFIG.map.rings[kind];
+
+    if (!fallback) {
+        return null;
+    }
+
+    const sizeKey =
+        RING_SIZE_KEYS[kind];
+
+    const configured =
+        APP_CONFIG
+            ?.map
+            ?.rings
+            ?.[kind];
+
+    const size =
+        Number(
+            configured?.[sizeKey]
+        );
+
+    const color =
+        typeof configured?.color === 'string' &&
+        /^#[0-9a-fA-F]{6}$/.test(configured.color)
+            ? configured.color
+            : fallback.color;
+
+    return {
+        size:
+            Number.isFinite(size) &&
+            size > 0
+                ? size
+                : fallback[sizeKey],
+        color
+    };
 }
 
 function getCameraPanSpeed() {

--- a/js/events.js
+++ b/js/events.js
@@ -715,6 +715,15 @@ function bindEvents() {
 
             e.preventDefault();
 
+            /*
+             * With the marker tool active, the wheel turns the FOB build
+             * area under the cursor instead of zooming. Everywhere else —
+             * every other tool, every other spot on the map — it zooms.
+             */
+            if (handleMapToolWheel(e)) {
+                return;
+            }
+
             const rect =
                 c.getBoundingClientRect();
 

--- a/js/map/map-tools.js
+++ b/js/map/map-tools.js
@@ -49,6 +49,7 @@ const MAP_TOOL_STATE = {
 
     rotationDrag: null,
     wheelRotation: null,
+    moveDrag: null,
 
     searchPoint: null,
 
@@ -182,6 +183,7 @@ function restoreMapToolContent(snapshot) {
     MAP_TOOL_STATE.hoverDeletePoint = null;
     MAP_TOOL_STATE.hoverMarkerId = null;
     MAP_TOOL_STATE.rotationDrag = null;
+    MAP_TOOL_STATE.moveDrag = null;
 
     saveMapToolState();
     inputs();
@@ -543,9 +545,10 @@ async function importMapToolChanges() {
 }
 
 function setMapTool(tool) {
-    /* Leaving the marker tool ends any rotation still in progress. */
+    /* Leaving the marker tool ends any gesture still in progress. */
     flushMarkerWheelRotation();
     finishMarkerRotationDrag();
+    finishMarkerMoveDrag();
 
     MAP_TOOL_STATE.tool =
         MAP_TOOL_STATE.tool === tool
@@ -2748,6 +2751,110 @@ function resetMarkerRotation(item) {
     draw();
 }
 
+/* =========================
+   MARKER MOVING
+   ========================= */
+
+/*
+ * Pressing on a marker that is already on the map picks it up instead of
+ * dropping a second one at the same spot. Like rotation, a move is one
+ * gesture: history is taken on the first pixel that actually moves it,
+ * and the save happens once on release. A press that never moves
+ * therefore changes nothing at all.
+ */
+function beginMarkerMoveDrag(item, world) {
+    MAP_TOOL_STATE.moveDrag = {
+        id: item.id,
+        start: {
+            x: item.x,
+            y: item.y
+        },
+        offset: {
+            x: item.x - world.x,
+            y: item.y - world.y
+        },
+        historyPushed: false
+    };
+
+    draw();
+}
+
+function updateMarkerMoveDrag(world) {
+    const gesture =
+        MAP_TOOL_STATE.moveDrag;
+
+    if (!gesture) {
+        return false;
+    }
+
+    const item =
+        findMarkerById(gesture.id);
+
+    if (!item) {
+        MAP_TOOL_STATE.moveDrag = null;
+        return false;
+    }
+
+    const next = {
+        x: world.x + gesture.offset.x,
+        y: world.y + gesture.offset.y
+    };
+
+    /*
+     * Dragging past the edge leaves the marker at the last good spot
+     * rather than following the cursor off the map.
+     */
+    if (
+        !isWorldPointInsideMap(next) ||
+        (
+            next.x === item.x &&
+            next.y === item.y
+        )
+    ) {
+        return true;
+    }
+
+    if (!gesture.historyPushed) {
+        gesture.historyPushed = true;
+        pushMapToolHistory();
+    }
+
+    item.x = next.x;
+    item.y = next.y;
+
+    draw();
+
+    return true;
+}
+
+function finishMarkerMoveDrag() {
+    const gesture =
+        MAP_TOOL_STATE.moveDrag;
+
+    if (!gesture) {
+        return false;
+    }
+
+    MAP_TOOL_STATE.moveDrag = null;
+
+    const item =
+        findMarkerById(gesture.id);
+
+    if (
+        item &&
+        (
+            item.x !== gesture.start.x ||
+            item.y !== gesture.start.y
+        )
+    ) {
+        saveMapToolState();
+    }
+
+    draw();
+
+    return true;
+}
+
 /*
  * Wheel ticks arrive one at a time, so a burst is stitched into a single
  * gesture: the first tick takes the history snapshot, and a short idle
@@ -2919,6 +3026,24 @@ function handleMapToolMouseDown(
 
                 return true;
             }
+
+            const bodyHit =
+                findMapToolMarkerAtCanvasPoint(
+                    mouseX,
+                    mouseY
+                );
+
+            if (
+                bodyHit &&
+                bodyHit.id === item.id
+            ) {
+                beginMarkerMoveDrag(
+                    item,
+                    world
+                );
+
+                return true;
+            }
         }
     }
 
@@ -2982,6 +3107,10 @@ function handleMapToolMouseMove(
 
     if (MAP_TOOL_STATE.rotationDrag) {
         return updateMarkerRotationDrag(event);
+    }
+
+    if (MAP_TOOL_STATE.moveDrag) {
+        return updateMarkerMoveDrag(world);
     }
 
     if (
@@ -3074,6 +3203,10 @@ function handleMapToolMouseMove(
 
 function handleMapToolMouseUp() {
     if (finishMarkerRotationDrag()) {
+        return true;
+    }
+
+    if (finishMarkerMoveDrag()) {
         return true;
     }
 

--- a/js/map/map-tools.js
+++ b/js/map/map-tools.js
@@ -47,6 +47,9 @@ const MAP_TOOL_STATE = {
     hoverDeletePoint: null,
     hoverMarkerId: null,
 
+    rotationDrag: null,
+    wheelRotation: null,
+
     searchPoint: null,
 
     undoStack: [],
@@ -81,6 +84,23 @@ function mapToolId() {
 
 function currentMapToolMapId() {
     return S.map || 'custom';
+}
+
+/*
+ * Marker rotation is degrees clockwise, wrapped into [0, 360). Anything
+ * unusable — a missing field on an older marker, a hand-edited import —
+ * becomes 0, which is the axis-aligned square markers had before.
+ */
+function normalizeMarkerRotation(value) {
+    const degrees = Number(value);
+
+    if (!Number.isFinite(degrees)) {
+        return 0;
+    }
+
+    return (
+        (degrees % 360) + 360
+    ) % 360;
 }
 
 function snapshotMapToolContent() {
@@ -161,6 +181,7 @@ function restoreMapToolContent(snapshot) {
     MAP_TOOL_STATE.hoverPathId = null;
     MAP_TOOL_STATE.hoverDeletePoint = null;
     MAP_TOOL_STATE.hoverMarkerId = null;
+    MAP_TOOL_STATE.rotationDrag = null;
 
     saveMapToolState();
     inputs();
@@ -190,6 +211,13 @@ function resetMapToolHistory() {
 }
 
 function undoMapToolAction() {
+    /*
+     * A wheel burst only lands when it goes quiet, so close any burst
+     * still in flight before undoing — otherwise the undo targets a
+     * rotation that has not been recorded yet.
+     */
+    flushMarkerWheelRotation();
+
     if (!MAP_TOOL_STATE.undoStack.length) {
         return false;
     }
@@ -206,6 +234,8 @@ function undoMapToolAction() {
 }
 
 function redoMapToolAction() {
+    flushMarkerWheelRotation();
+
     if (!MAP_TOOL_STATE.redoStack.length) {
         return false;
     }
@@ -400,7 +430,8 @@ function normalizeImportedMapToolMarker(marker) {
         mapId: importedMapId(marker.mapId),
         icon: marker.icon,
         x: Number(marker.x),
-        y: Number(marker.y)
+        y: Number(marker.y),
+        rotation: normalizeMarkerRotation(marker.rotation)
     };
 }
 
@@ -512,6 +543,10 @@ async function importMapToolChanges() {
 }
 
 function setMapTool(tool) {
+    /* Leaving the marker tool ends any rotation still in progress. */
+    flushMarkerWheelRotation();
+    finishMarkerRotationDrag();
+
     MAP_TOOL_STATE.tool =
         MAP_TOOL_STATE.tool === tool
             ? null
@@ -2088,9 +2123,9 @@ function placeMapToolMarker(point) {
 /*
  * A FOB's build area is a square around the icon rather than a circle,
  * and it belongs to the marker rather than being its own object: place
- * the FOB icon and the area comes with it. That also means it needs no
- * state, no erasing and no history of its own — the marker it hangs off
- * already has all three.
+ * the FOB icon and the area comes with it. Its one adjustable property,
+ * `rotation`, lives on that marker too, so persistence, undo and export
+ * all come for free from the marker it hangs off.
  */
 function drawFobBuildAreas() {
 
@@ -2115,7 +2150,10 @@ function drawFobBuildAreas() {
                     marker.x,
                     marker.y,
                     config.size,
-                    config.color
+                    config.color,
+                    normalizeMarkerRotation(
+                        marker.rotation
+                    )
                 );
             }
         );
@@ -2357,8 +2395,42 @@ function getMapToolMarkerScreenGeometry(item) {
         right: left + width,
         bottom: top + height,
         deleteX: left + width + 3,
-        deleteY: top - 3
+        deleteY: top - 3,
+        rotateX: left - 3,
+        rotateY: top - 3
     };
+}
+
+/*
+ * Only the FOB's square turns, so only a FOB gets a grip. Anything else
+ * would offer a control with nothing to show for it.
+ */
+function markerSupportsRotation(item) {
+    return Boolean(item) && item.icon === 'fob';
+}
+
+function getRotatableMarkerAtCanvasPoint(
+    canvasX,
+    canvasY
+) {
+    const hit =
+        findMapToolMarkerAtCanvasPoint(
+            canvasX,
+            canvasY
+        );
+
+    if (!hit) {
+        return null;
+    }
+
+    const item =
+        MAP_TOOL_STATE.markers.find(
+            marker => marker.id === hit.id
+        );
+
+    return markerSupportsRotation(item)
+        ? item
+        : null;
 }
 
 function findMapToolMarkerAtCanvasPoint(
@@ -2442,6 +2514,331 @@ function updateMapToolMarkerHover(event) {
     }
 }
 
+/* =========================
+   MARKER ROTATION
+   ========================= */
+
+/*
+ * Rotating is deliberately hard to trigger by accident: it only works
+ * while the marker tool is active, and only on the FOB under the cursor.
+ * In every other mode the wheel keeps zooming the way it always has.
+ *
+ * A gesture — one wheel burst, one drag of the grip — pushes history once
+ * at its start and saves once at its end, so spinning a square does not
+ * fill the undo stack.
+ */
+const MARKER_ROTATION_WHEEL_STEP = 1;
+const MARKER_ROTATION_SNAP_STEP = 15;
+const MARKER_ROTATION_COMMIT_DELAY_MS = 400;
+
+function getMarkerRotation(item) {
+    return normalizeMarkerRotation(item?.rotation);
+}
+
+function setMarkerRotation(item, degrees) {
+    const next =
+        normalizeMarkerRotation(degrees);
+
+    if (getMarkerRotation(item) === next) {
+        return false;
+    }
+
+    item.rotation = next;
+
+    return true;
+}
+
+/*
+ * `startRotation` is the angle the gesture began at: a gesture that ends
+ * back where it started — a click on the grip that never moved — saves
+ * nothing.
+ */
+function commitMarkerRotation(item, startRotation) {
+    if (
+        !item ||
+        getMarkerRotation(item) === startRotation
+    ) {
+        return;
+    }
+
+    saveMapToolState();
+}
+
+/*
+ * The grip sits above the icon, so a pointer straight up from the centre
+ * reads as 0° — the same zero the square uses.
+ */
+function pointerAngleDegrees(center, canvasX, canvasY) {
+    return normalizeMarkerRotation(
+        Math.atan2(
+            canvasY - center.y,
+            canvasX - center.x
+        ) *
+        180 /
+        Math.PI +
+        90
+    );
+}
+
+function snapMarkerRotation(degrees) {
+    return normalizeMarkerRotation(
+        Math.round(
+            degrees / MARKER_ROTATION_SNAP_STEP
+        ) *
+        MARKER_ROTATION_SNAP_STEP
+    );
+}
+
+function findMarkerRotationGripAtCanvasPoint(
+    canvasX,
+    canvasY
+) {
+    if (
+        MAP_TOOL_STATE.tool !== 'marker' ||
+        !MAP_TOOL_STATE.hoverMarkerId
+    ) {
+        return null;
+    }
+
+    const item =
+        getHoveredMapToolMarker();
+
+    if (!markerSupportsRotation(item)) {
+        return null;
+    }
+
+    const geometry =
+        getMapToolMarkerScreenGeometry(item);
+
+    if (!geometry) {
+        return null;
+    }
+
+    return Math.hypot(
+        canvasX - geometry.rotateX,
+        canvasY - geometry.rotateY
+    ) <= 12
+        ? { item, geometry }
+        : null;
+}
+
+function findMarkerById(id) {
+    return (
+        MAP_TOOL_STATE.markers.find(
+            marker => marker.id === id
+        ) || null
+    );
+}
+
+/*
+ * History is taken on the first tick that actually moves the square, not
+ * when the gesture opens: grabbing the grip and letting go without turning
+ * anything should leave the undo stack alone.
+ */
+function rotateMarkerDuringGesture(gesture, item, degrees) {
+    if (
+        getMarkerRotation(item) ===
+        normalizeMarkerRotation(degrees)
+    ) {
+        return;
+    }
+
+    if (!gesture.historyPushed) {
+        gesture.historyPushed = true;
+        pushMapToolHistory();
+    }
+
+    setMarkerRotation(item, degrees);
+    draw();
+}
+
+function beginMarkerRotationDrag(hit, canvasX, canvasY) {
+    MAP_TOOL_STATE.rotationDrag = {
+        id: hit.item.id,
+        start: getMarkerRotation(hit.item),
+        historyPushed: false,
+        offset:
+            getMarkerRotation(hit.item) -
+            pointerAngleDegrees(
+                hit.geometry.center,
+                canvasX,
+                canvasY
+            )
+    };
+
+    draw();
+}
+
+function updateMarkerRotationDrag(event) {
+    const gesture =
+        MAP_TOOL_STATE.rotationDrag;
+
+    if (!gesture) {
+        return false;
+    }
+
+    const item =
+        findMarkerById(gesture.id);
+
+    if (!item) {
+        MAP_TOOL_STATE.rotationDrag = null;
+        return false;
+    }
+
+    const geometry =
+        getMapToolMarkerScreenGeometry(item);
+
+    if (!geometry) {
+        return true;
+    }
+
+    const rect =
+        c.getBoundingClientRect();
+
+    const next =
+        pointerAngleDegrees(
+            geometry.center,
+            event.clientX - rect.left,
+            event.clientY - rect.top
+        ) +
+        gesture.offset;
+
+    rotateMarkerDuringGesture(
+        gesture,
+        item,
+        event.shiftKey
+            ? snapMarkerRotation(next)
+            : next
+    );
+
+    return true;
+}
+
+function finishMarkerRotationDrag() {
+    const gesture =
+        MAP_TOOL_STATE.rotationDrag;
+
+    if (!gesture) {
+        return false;
+    }
+
+    MAP_TOOL_STATE.rotationDrag = null;
+
+    commitMarkerRotation(
+        findMarkerById(gesture.id),
+        gesture.start
+    );
+
+    draw();
+
+    return true;
+}
+
+function resetMarkerRotation(item) {
+    if (getMarkerRotation(item) === 0) {
+        return;
+    }
+
+    const start =
+        getMarkerRotation(item);
+
+    pushMapToolHistory();
+    setMarkerRotation(item, 0);
+    commitMarkerRotation(item, start);
+    draw();
+}
+
+/*
+ * Wheel ticks arrive one at a time, so a burst is stitched into a single
+ * gesture: the first tick takes the history snapshot, and a short idle
+ * afterwards saves the result.
+ */
+function flushMarkerWheelRotation() {
+    const gesture =
+        MAP_TOOL_STATE.wheelRotation;
+
+    if (!gesture) {
+        return;
+    }
+
+    clearTimeout(gesture.timer);
+
+    MAP_TOOL_STATE.wheelRotation = null;
+
+    commitMarkerRotation(
+        findMarkerById(gesture.id),
+        gesture.start
+    );
+}
+
+function handleMapToolWheel(event) {
+    if (MAP_TOOL_STATE.tool !== 'marker') {
+        return false;
+    }
+
+    const rect =
+        c.getBoundingClientRect();
+
+    const item =
+        getRotatableMarkerAtCanvasPoint(
+            event.clientX - rect.left,
+            event.clientY - rect.top
+        );
+
+    if (!item) {
+        return false;
+    }
+
+    /*
+     * Moving on to a different FOB ends the previous burst rather than
+     * folding two markers into one gesture.
+     */
+    if (
+        MAP_TOOL_STATE.wheelRotation &&
+        MAP_TOOL_STATE.wheelRotation.id !== item.id
+    ) {
+        flushMarkerWheelRotation();
+    }
+
+    const gesture =
+        MAP_TOOL_STATE.wheelRotation || {
+            id: item.id,
+            start: getMarkerRotation(item),
+            historyPushed: false,
+            timer: null
+        };
+
+    const direction =
+        event.deltaY < 0
+            ? 1
+            : -1;
+
+    const current =
+        getMarkerRotation(item);
+
+    rotateMarkerDuringGesture(
+        gesture,
+        item,
+        event.shiftKey
+            ? snapMarkerRotation(current) +
+              direction * MARKER_ROTATION_SNAP_STEP
+            : current +
+              direction * MARKER_ROTATION_WHEEL_STEP
+    );
+
+    clearTimeout(gesture.timer);
+
+    gesture.timer =
+        setTimeout(
+            flushMarkerWheelRotation,
+            MARKER_ROTATION_COMMIT_DELAY_MS
+        );
+
+    MAP_TOOL_STATE.wheelRotation = gesture;
+
+    return true;
+}
+
 function handleMapToolMouseDown(
     event,
     world
@@ -2496,6 +2893,30 @@ function handleMapToolMouseDown(
                 ) <= 12
             ) {
                 deleteHoveredMapToolMarker();
+                return true;
+            }
+
+            const gripHit =
+                findMarkerRotationGripAtCanvasPoint(
+                    mouseX,
+                    mouseY
+                );
+
+            if (gripHit) {
+                /*
+                 * Second click of a double-click on the grip snaps the
+                 * square back to straight.
+                 */
+                if (event.detail >= 2) {
+                    resetMarkerRotation(gripHit.item);
+                } else {
+                    beginMarkerRotationDrag(
+                        gripHit,
+                        mouseX,
+                        mouseY
+                    );
+                }
+
                 return true;
             }
         }
@@ -2557,6 +2978,10 @@ function handleMapToolMouseMove(
 ) {
     if (!MAP_TOOL_STATE.tool) {
         return false;
+    }
+
+    if (MAP_TOOL_STATE.rotationDrag) {
+        return updateMarkerRotationDrag(event);
     }
 
     if (
@@ -2648,6 +3073,10 @@ function handleMapToolMouseMove(
 }
 
 function handleMapToolMouseUp() {
+    if (finishMarkerRotationDrag()) {
+        return true;
+    }
+
     if (
         MAP_TOOL_STATE.rulerDragging
     ) {
@@ -3189,6 +3618,131 @@ function drawMarkerDeleteAffordance() {
     ctx.restore();
 }
 
+/*
+ * The rotate grip mirrors the delete badge on the other top corner, and
+ * only appears with the marker tool active — the same gate the wheel uses,
+ * so what you can see is exactly what you can do.
+ */
+function drawMarkerRotateAffordance() {
+    const dragging =
+        MAP_TOOL_STATE.rotationDrag;
+
+    const item =
+        dragging
+            ? findMarkerById(dragging.id)
+            : MAP_TOOL_STATE.tool === 'marker'
+                ? getHoveredMapToolMarker()
+                : null;
+
+    if (!markerSupportsRotation(item)) {
+        return;
+    }
+
+    const geometry =
+        getMapToolMarkerScreenGeometry(item);
+
+    if (!geometry) {
+        return;
+    }
+
+    const v = view();
+
+    const point = {
+        x: geometry.rotateX - v.left,
+        y: geometry.rotateY - v.top
+    };
+
+    const color =
+        getRingConfig('fob')?.color ||
+        '#5fa8d3';
+
+    ctx.save();
+
+    ctx.beginPath();
+    ctx.arc(
+        point.x,
+        point.y,
+        10,
+        0,
+        Math.PI * 2
+    );
+    ctx.fillStyle =
+        'rgba(16, 19, 22, .95)';
+    ctx.fill();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.75;
+    ctx.lineCap = 'round';
+
+    /* An open circle with an arrowhead: the usual "turn this" glyph. */
+    ctx.beginPath();
+    ctx.arc(
+        point.x,
+        point.y,
+        4.5,
+        Math.PI * 0.35,
+        Math.PI * 2
+    );
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.moveTo(
+        point.x + 1.5,
+        point.y - 6.5
+    );
+    ctx.lineTo(
+        point.x + 4.5,
+        point.y - 4.5
+    );
+    ctx.lineTo(
+        point.x + 6.5,
+        point.y - 7.5
+    );
+    ctx.stroke();
+
+    ctx.restore();
+
+    if (
+        !dragging &&
+        getMarkerRotation(item) === 0
+    ) {
+        return;
+    }
+
+    ctx.save();
+
+    ctx.font =
+        '600 11px system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'top';
+
+    const label =
+        `${Math.round(
+            getMarkerRotation(item)
+        )}°`;
+
+    ctx.lineWidth = 3;
+    ctx.strokeStyle =
+        'rgba(0, 0, 0, 0.75)';
+    ctx.strokeText(
+        label,
+        point.x,
+        point.y + 12
+    );
+
+    ctx.fillStyle = color;
+    ctx.fillText(
+        label,
+        point.x,
+        point.y + 12
+    );
+
+    ctx.restore();
+}
+
 function drawCoordinateSearchPoint() {
     const point = MAP_TOOL_STATE.searchPoint;
 
@@ -3220,4 +3774,5 @@ function drawMapToolTransient() {
     drawRulerOverlay();
     drawEraserAffordance();
     drawMarkerDeleteAffordance();
+    drawMarkerRotateAffordance();
 }

--- a/js/map/map-tools.js
+++ b/js/map/map-tools.js
@@ -65,6 +65,7 @@ const MAP_TOOL_STATE = {
         presetMarkers: true,
         drawings: true,
         userMarkers: true,
+        fobAreas: true,
         artillery: true,
         cursorCoords: true
     }
@@ -1014,6 +1015,7 @@ function buildMapLayers() {
                 ['zones', 'mapLayerZones'],
                 ['polygons', 'mapLayerPolygons'],
                 ['presetMarkers', 'mapLayerPresetMarkers'],
+                ['fobAreas', 'mapLayerFobAreas'],
                 ['artillery', 'mapLayerArtillery']
             ]
         },
@@ -1059,6 +1061,10 @@ function buildMapLayers() {
         userMarkers: `
             <path d="M12 21s6-5.1 6-11a6 6 0 1 0-12 0c0 5.9 6 11 6 11Z"/>
             <path d="m12 7 .9 1.8 2 .3-1.45 1.4.35 2-1.8-.95-1.8.95.35-2-1.45-1.4 2-.3Z"/>
+        `,
+        fobAreas: `
+            <path d="M5 19V9l7-4 7 4v10Z"/>
+            <path d="M9.5 19v-5h5v5"/>
         `,
         artillery: `
             <circle cx="12" cy="12" r="6"/>
@@ -2073,6 +2079,46 @@ function placeMapToolMarker(point) {
     }
 
     draw();
+}
+
+/* =========================
+   FOB BUILD AREAS
+   ========================= */
+
+/*
+ * A FOB's build area is a square around the icon rather than a circle,
+ * and it belongs to the marker rather than being its own object: place
+ * the FOB icon and the area comes with it. That also means it needs no
+ * state, no erasing and no history of its own — the marker it hangs off
+ * already has all three.
+ */
+function drawFobBuildAreas() {
+
+    const config =
+        getRingConfig('fob');
+
+    if (!config) {
+        return;
+    }
+
+    MAP_TOOL_STATE.markers
+        .filter(
+            marker =>
+                marker.icon === 'fob' &&
+                marker.mapId ===
+                currentMapToolMapId()
+        )
+        .forEach(
+            marker => {
+
+                drawRadiusSquare(
+                    marker.x,
+                    marker.y,
+                    config.size,
+                    config.color
+                );
+            }
+        );
 }
 
 function findPencilPathAtCanvasPoint(

--- a/js/map/overlays.js
+++ b/js/map/overlays.js
@@ -65,14 +65,16 @@ function marker(
 /*
  * A FOB's build area is a square, not a circle, so it gets its own
  * primitive. `halfExtent` is the in-game distance from the centre to an
- * edge — the full side is twice that. Axis-aligned, matching the way
- * build volumes sit against the world grid.
+ * edge — the full side is twice that. `rotationDegrees` turns the square
+ * about its centre, because a FOB dropped in-game rarely lands square
+ * with the world grid.
  */
 function drawRadiusSquare(
     worldX,
     worldY,
     halfExtentMeters,
-    color
+    color,
+    rotationDegrees = 0
 ) {
 
     const v =
@@ -104,6 +106,22 @@ function drawRadiusSquare(
     const side =
         half * 2;
 
+    const angle =
+        (
+            Number(rotationDegrees) || 0
+        ) *
+        Math.PI /
+        180;
+
+    ctx.save();
+
+    ctx.translate(
+        pos.x,
+        pos.y
+    );
+
+    ctx.rotate(angle);
+
     ctx.fillStyle =
         hexToRgba(
             stroke,
@@ -111,8 +129,8 @@ function drawRadiusSquare(
         );
 
     ctx.fillRect(
-        pos.x - half,
-        pos.y - half,
+        -half,
+        -half,
         side,
         side
     );
@@ -129,13 +147,15 @@ function drawRadiusSquare(
     ]);
 
     ctx.strokeRect(
-        pos.x - half,
-        pos.y - half,
+        -half,
+        -half,
         side,
         side
     );
 
     ctx.setLineDash([]);
+
+    ctx.restore();
 }
 
 

--- a/js/map/overlays.js
+++ b/js/map/overlays.js
@@ -59,6 +59,87 @@ function marker(
 
 
 /* =========================
+   FOB BUILD AREAS
+   ========================= */
+
+/*
+ * A FOB's build area is a square, not a circle, so it gets its own
+ * primitive. `halfExtent` is the in-game distance from the centre to an
+ * edge — the full side is twice that. Axis-aligned, matching the way
+ * build volumes sit against the world grid.
+ */
+function drawRadiusSquare(
+    worldX,
+    worldY,
+    halfExtentMeters,
+    color
+) {
+
+    const v =
+        view();
+
+    const pos =
+        worldToLocalScreen(
+            worldX,
+            worldY
+        );
+
+    const half =
+        metersToWorldDistance(
+            halfExtentMeters
+        ) *
+        v.scale;
+
+    if (
+        !Number.isFinite(half) ||
+        half <= 0
+    ) {
+        return;
+    }
+
+    const stroke =
+        color ||
+        '#d7a452';
+
+    const side =
+        half * 2;
+
+    ctx.fillStyle =
+        hexToRgba(
+            stroke,
+            0.12
+        );
+
+    ctx.fillRect(
+        pos.x - half,
+        pos.y - half,
+        side,
+        side
+    );
+
+    ctx.strokeStyle =
+        stroke;
+
+    ctx.lineWidth =
+        2;
+
+    ctx.setLineDash([
+        7,
+        5
+    ]);
+
+    ctx.strokeRect(
+        pos.x - half,
+        pos.y - half,
+        side,
+        side
+    );
+
+    ctx.setLineDash([]);
+}
+
+
+/* =========================
    PRESET ZONES
    ========================= */
 

--- a/js/map/renderer.js
+++ b/js/map/renderer.js
@@ -152,6 +152,14 @@ function draw() {
     }
 
     /*
+     * Build areas sit under the drawings and markers, so the FOB icon
+     * they belong to stays legible on top of its own square.
+     */
+    if (isMapLayerVisible('fobAreas')) {
+        drawFobBuildAreas();
+    }
+
+    /*
      * User pencil drawings are persistent
      * map annotations and live below the
      * artillery solution overlays.

--- a/locales/en.json
+++ b/locales/en.json
@@ -71,6 +71,7 @@
   "mapLayerPresetMarkers": "Map markers",
   "mapLayerDrawings": "Drawings",
   "mapLayerUserMarkers": "User markers",
+  "mapLayerFobAreas": "FOB build areas",
   "mapLayerArtillery": "Artillery overlay",
   "mapToolUndo": "Undo",
   "mapToolRedo": "Redo",


### PR DESCRIPTION
Rebased onto current main and unstacked from #9 — the diff here is now only the FOB build-area work, three commits, no merge commit. It still needs the tactical markers branch, not yet opened, before any of this is reachable in the UI: the build area is drawn around a placed marker whose icon id is "fob", and that icon does not exist until that branch lands. Until then the code is inert rather than broken, drawing nothing and leaving the wheel to zoom as it always has.

Adds a "fob" ring kind measured by halfSide, the distance from the FOB to an edge, so the buildable side is twice it. A square, not a circle, so it gets its own drawing primitive rather than reusing the ring.

The square turns with the wheel while the marker tool is active and the cursor is over a FOB, or by dragging the grip on the icon's top-left corner. Shift snaps to 15 degrees, double-clicking the grip straightens it. Rotation lives on the marker, so undo, export and persistence come for free.

Pressing a marker that is already placed now picks it up and moves it instead of stacking a second one on top.

The 60 m half-side is confirmed from the game data — the build area is a 120 x 120 m square — so the placeholder wording in config.js is gone with it.

Only en has the new mapLayerFobAreas string; the other eleven fall back to English and are worth one follow-up pass.

<img width="494" height="429" alt="image" src="https://github.com/user-attachments/assets/9f18be14-e81a-4848-931c-87c13241e25c" />